### PR TITLE
依存関係の修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libprelude gnutls libtasn1 lib64nettle nettle
+RUN yumdownloader -x *i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libprelude gnutls libtasn1 lib64nettle nettle libtool-ltdl bzip2-libs libxml2 xz-libs libgcrypt libgpg-error
 RUN rpm2cpio clamav-0*.rpm | cpio -idmv
 RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
 RUN rpm2cpio clamav-update*.rpm | cpio -idmv
@@ -32,6 +32,13 @@ RUN rpm2cpio nettle* | cpio -idmv
 RUN rpm2cpio lib* | cpio -idmv
 RUN rpm2cpio *.rpm | cpio -idmv
 RUN rpm2cpio libtasn1* | cpio -idmv
+RUN rpm2cpio libtool-ltdl*.rpm | cpio -idmv
+RUN rpm2cpio bzip2-libs*.rpm | cpio -idmv
+RUN rpm2cpio libxml2*.rpm | cpio -idmv
+RUN rpm2cpio xz-libs*.rpm | cpio -idmv
+RUN rpm2cpio libgcrypt*.rpm | cpio -idmv
+RUN rpm2cpio libgpg-error*.rpm | cpio -idmv
+RUN rpm2cpio libprelude*.rpm | cpio -idmv
 
 # Copy over the binaries and libraries
 RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /opt/app/bin/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-certifi==2018.11.29
+certifi==2022.5.18.1
 chardet==3.0.4
-datadog==0.26.0
+datadog==0.44.0
 decorator==4.3
 idna==2.8
-requests==2.21
+requests==2.27.1
 simplejson==3.16
-urllib3==1.24.2
-pytz==2019.3
+urllib3==1.26.9
+pytz==2022.1


### PR DESCRIPTION
* ClamAV最新版を動作させるための依存関係修正（Dockerfile）
    * see: https://github.com/bluesentry/bucket-antivirus-function/issues/138
* requirements.txtのパッケージ更新
    * urllib3はbotocore最新版とincompatibleであるとのWarningが出る
    * 他、目に付いた箇所。